### PR TITLE
Updating `findProperty` to return valid responses

### DIFF
--- a/examples/python/papi_tools.py
+++ b/examples/python/papi_tools.py
@@ -174,7 +174,8 @@ def findProperty(propertyName, config):
 					property = getPropertyInfo(		propertyName, 
 													groupId, 
 													contractId)
-					return property
+					if property:
+						return property
 				else:
 					print "Need a property to make this go."
 					exit(0)


### PR DESCRIPTION
I added a check to `findProperty` that only returns a property if its discovered value isn't `None`. This was needed to make the diff work for me (before, it only worked if there was a valid property in the *first* group/contract combination).