### PR TITLE
Patch to handle 204 responses correctly

### DIFF
--- a/examples/python/http_calls.py
+++ b/examples/python/http_calls.py
@@ -99,9 +99,11 @@ class EdgeGridHttpCaller():
         else:
             path = endpoint
         endpoint_result = self.session.post(urljoin(self.baseurl,path), data=body, headers=headers)
-        self.httpErrors(endpoint_result.status_code, path, endpoint_result.json())
 	status = endpoint_result.status_code
 	if self.verbose: print "LOG: POST %s %s %s" % (path,status,endpoint_result.headers["content-type"])
+        if status == 204:
+            return {}
+        self.httpErrors(endpoint_result.status_code, path, endpoint_result.json())
 
         if self.verbose: print ">>>\n" + json.dumps(endpoint_result.json(), indent=2) + "\n<<<\n"
         return endpoint_result.json()
@@ -114,14 +116,18 @@ class EdgeGridHttpCaller():
           else:
                   path = endpoint
           endpoint_result = self.session.put(urljoin(self.baseurl,path), data=body, headers=headers)
-          if self.verbose: print ">>>\n" + json.dumps(endpoint_result.json(), indent=2) + "\n<<<\n"
           status = endpoint_result.status_code
 	  if self.verbose: print "LOG: PUT %s %s %s" % (endpoint,status,endpoint_result.headers["content-type"])
+          if status == 204:
+              return {}
+          if self.verbose: print ">>>\n" + json.dumps(endpoint_result.json(), indent=2) + "\n<<<\n"
           return endpoint_result.json()
 
     def deleteResult(self, endpoint):
           endpoint_result = self.session.delete(urljoin(self.baseurl,endpoint))
-          if self.verbose: print ">>>\n" + json.dumps(endpoint_result.json(), indent=2) + "\n<<<\n"
 	  status = endpoint_result.status_code
 	  if self.verbose: print "LOG: DELETE %s %s %s" % (endpoint,status,endpoint_result.headers["content-type"])
+          if status == 204:
+              return {}
+          if self.verbose: print ">>>\n" + json.dumps(endpoint_result.json(), indent=2) + "\n<<<\n"
           return endpoint_result.json()


### PR DESCRIPTION
HTTP 204 responses have no content, so calling .json() on them results in a ValueError.  This fixes http_calls to return an empty dictionary when there's a 204 response to a PUT, DELETE, or POST.  

Unfortunately, an empty dictionary evaluates to False when treated as a boolean, but the alternative is to return either True (which means the function could alternately return a dict or a bool, which isn't great), or None, which also evaluates to False.

Note: I kept the original mix of tabs, spaces, and varying indent levels intact for better diff readability.
