### PR TITLE
Update http_calls.py

### DIFF
--- a/examples/python/http_calls.py
+++ b/examples/python/http_calls.py
@@ -53,7 +53,7 @@ class EdgeGridHttpCaller():
                     error_msg +=  "ERROR: This indicates a problem with authorization.\n"
                     error_msg +=  "ERROR: Please ensure that the credentials you created for this script\n"
                     error_msg +=  "ERROR: have the necessary permissions in the Luna portal.\n"
-                    error_msg +=  "ERROR: Problem details: %s\n" % result["details"]
+                    error_msg +=  "ERROR: Problem details: %s\n" % result["detail"]
                     exit(error_msg)
       
       if status_code in [400, 401]:


### PR DESCRIPTION
'details' is not in the response, but should be 'detail'. 
example 403 response:
  {u'status': 403, u'requestTime': u'2016-09-20T02:27:02Z', u'title': u'Forbidden', u'detail': u'The client does not have the grant needed for the request', u'serverIp': u'104.95.128.31', u'authzRealm': u'xxxxxxxxxxxxxxxxxxxxxxxxxxxxx', u'instance': u'https://xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.purge.akamaiapis.net/ccu/v2/queues/default', u'requestId': u'30602e49', u'clientIp': u'xx.xx.xx.xx', u'type': u'https://problems.purge.akamaiapis.net/-/pep-authz/deny', u'method': u'POST'}