### PR TITLE
Use action variable instead of type metaclass in ccu_v3.py

### DIFF
--- a/examples/python/ccu_v3.py
+++ b/examples/python/ccu_v3.py
@@ -74,7 +74,7 @@ def postPurgeRequest(action = "invalidate"):
 				"/index.html"
 			]
 		    }
-	print ("Adding %s to queue - %s" % (type, json.dumps(purge_obj)));
+	print ("Adding %s request to queue - %s" % (action, json.dumps(purge_obj)));
 	purge_post_result = httpCaller.postResult('/ccu/v3/invalidate/url', json.dumps(purge_obj))
 	return purge_post_result
 


### PR DESCRIPTION
Remove built-in **type** metaclass from print and added **action** in place of type in line 77 of file
`examples/python/ccu_v3.py`

**Current Output:** 
`Adding <type 'type'> to queue - {"hostname": "www.example.com", "objects": ["/index.html"]}
LOG: POST /ccu/v3/invalidate/url 201 application/json
`

**Updated Output:**
`Adding invalidate request to queue - {"hostname": "www.example.com", "objects": ["/index.html"]}
LOG: POST /ccu/v3/invalidate/url 201 application/json
`